### PR TITLE
bindShared should be singleton in

### DIFF
--- a/src/AdminGeneratorServiceProvider.php
+++ b/src/AdminGeneratorServiceProvider.php
@@ -39,11 +39,11 @@ class AdminGeneratorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bindShared('le-admin.command.instance.new', function ($app) {
+        $this->app->singleton('le-admin.command.instance.new', function ($app) {
             return $app->make('Lokielse\AdminGenerator\Console\Commands\CreateInstanceCommand');
         });
 
-        $this->app->bindShared('le-admin.command.entity.new', function ($app) {
+        $this->app->singleton('le-admin.command.entity.new', function ($app) {
             return $app->make('Lokielse\AdminGenerator\Console\Commands\CreateEntityCommand');
         });
 


### PR DESCRIPTION
With laravel framework 5.2.10

  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Fatal error: Call to undefined method Illuminate\Foundation\Application::bindShared()

bindShared is removed and singleton should be used instead https://github.com/laravel/framework/commit/4b57379796a6c548d331bc1e622d51f3eb5904ca

Starting from 5.1
https://github.com/laravel/framework/pull/9009
