### PR TITLE
Fix directory separator on Windows

### DIFF
--- a/src/Console/Commands/CreateInstanceCommand.php
+++ b/src/Console/Commands/CreateInstanceCommand.php
@@ -77,8 +77,8 @@ class CreateInstanceCommand extends Command
             if ($file->isFile()) {
                 var_dump($file->getFilename());
 
-                $relativePath = str_replace($basePath . "/engines/{$engine}/", '', $file->getRealPath());
-                $dest         = base_path('resources/' . $relativePath);
+                $relativePath = str_replace($basePath . DIRECTORY_SEPARATOR . "engines". DIRECTORY_SEPARATOR . $engine . DIRECTORY_SEPARATOR, '', $file->getRealPath());
+                $dest         = base_path('resources' . DIRECTORY_SEPARATOR . $relativePath);
                 $dest         = $this->replaceKeyword($dest);
                 if (is_file($dest) && ! $force) {
                     $this->warn(sprintf("The file '%s' exists, use '--force' option to overwrite it.", str_replace(base_path(), '', $dest)));


### PR DESCRIPTION
Finding relative path fails on windows since "\" != "/"

For this reason / is replaced in here with DIRECTORY_SEPARATOR http://php.net/manual/en/dir.constants.php
