### PR TITLE
Fix missing ngtemplatecache

### DIFF
--- a/docs/1-Installation.md
+++ b/docs/1-Installation.md
@@ -25,6 +25,7 @@ NPM
 ---
 ```bash
 npm install laravel-elixir-ng-templates@^0.1.2 --save
+npm install laravel-elixir-ngtemplatecache@^0.2.0 --save
 npm install underscore --save
 ```
 


### PR DESCRIPTION
Without explicit install of laravel-elixir-ngtemplatecache gulp tasks will not find it and fail.

npm 3.5.0
gulp 3.9.0
